### PR TITLE
fix: Добавить отсутствующие package.json и .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Dependencies
+/node_modules
+
+# Local database file
+db.json
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+pnpm-debug.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vip-auto-logbook",
+  "version": "1.0.0",
+  "description": "Cloud logbook for auto service",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
Добавлены два критически важных файла, которые были утеряны после сброса проекта:
- `package.json`: Определяет зависимости проекта (`express`, `socket.io` и т.д.) и стартовый скрипт. Его отсутствие приводило к провалу сборки на Render.
- `.gitignore`: Исключает из репозитория ненужные файлы, такие как `node_modules` и локальную базу данных `db.json`.