### PR TITLE
fix(css): Apply final polish to license plate component

### DIFF
--- a/css/components/order-item.css
+++ b/css/components/order-item.css
@@ -35,7 +35,7 @@
 .license-plate {
     display: inline-flex;
     align-items: stretch;
-    border: 1px solid #333;
+    border: 2px solid #333;
     border-radius: 4px;
     background-color: #fff;
     color: #000;
@@ -44,8 +44,8 @@
     text-transform: uppercase;
     overflow: hidden;
     box-shadow: 0 1px 1px rgba(0,0,0,0.1);
-    font-size: 0.9em; /* Reduced base size */
-    height: 28px; /* Reduced height */
+    font-size: 0.85em; /* Further reduced base size for overall compactness */
+    height: 28px;
 }
 .license-plate-fallback {
     padding: 2px 8px;
@@ -58,27 +58,28 @@
     gap: 0.1em;
 }
 .plate-letter, .plate-letters {
-    font-size: 0.9em; /* Letters are smaller than digits */
-    transform: scaleY(0.95); /* Slightly squash letters */
+    font-size: 1em; /* Base size for letters */
+    transform: scaleY(0.95);
     display: inline-block;
 }
 .plate-digits {
-    font-size: 1.1em; /* Digits are larger */
+    font-size: 1.15em; /* 15% larger than letters */
     letter-spacing: 0.5px;
 }
 .plate-region {
-    border-left: 1px solid #333;
+    border-left: 2px solid #333;
     padding: 2px 6px;
     text-align: center;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    min-width: 36px; /* Give region a bit of space */
+    min-width: 36px;
 }
 .region-code {
-    font-size: 1.2em;
+    font-size: 0.8em; /* Significantly smaller region code */
     line-height: 1;
+    font-weight: 600;
 }
 .region-flag {
     display: flex;


### PR DESCRIPTION
This commit applies a final round of specific CSS adjustments to the license plate component based on detailed user feedback.

- The main border of the license plate is set back to 2px.
- The font-size of the main digits is now exactly 15% larger than the letters.
- The font-size of the region code has been significantly reduced for a more realistic appearance.