### PR TITLE
fix(css): Increase digit size on license plate

### DIFF
--- a/css/components/order-item.css
+++ b/css/components/order-item.css
@@ -63,7 +63,7 @@
     display: inline-block;
 }
 .plate-digits {
-    font-size: 1.15em; /* 15% larger than letters */
+    font-size: 1.38em; /* Further increased size as requested */
     letter-spacing: 0.5px;
 }
 .plate-region {


### PR DESCRIPTION
This commit increases the font size of the main digits on the license plate component by an additional 20% as per user request, making them more prominent.