### PR TITLE
fix(css): Correct vertical alignment of license plate digits

### DIFF
--- a/css/components/order-item.css
+++ b/css/components/order-item.css
@@ -52,7 +52,7 @@
 .plate-main {
     padding: 2px 8px;
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 0.1em;
 }
 .plate-letter, .plate-letters {


### PR DESCRIPTION
This commit changes the flexbox alignment for the main part of the license plate from 'baseline' back to 'center'.

This ensures that the oversized digits are properly centered vertically within the component's border, preventing them from overflowing, which was happening with baseline alignment due to the large font size difference.