### PR TITLE
fix(css): Final alignment of license plate text

### DIFF
--- a/css/components/order-item.css
+++ b/css/components/order-item.css
@@ -59,6 +59,8 @@
     font-size: 1em; /* Base size for letters */
     transform: scaleY(0.95);
     display: inline-block;
+    position: relative;
+    top: 0.12em; /* Nudge letters down to align with baseline of larger digits */
 }
 .plate-digits {
     font-size: 1.725em; /* Increased by 25% from 1.38em */


### PR DESCRIPTION
This commit applies a final, nuanced alignment fix to the license plate component.

- The main flex container (`plate-main`) remains vertically centered to keep the large digits positioned correctly.
- `position: relative` is used on the smaller letter elements to nudge them down slightly, aligning their baseline with the baseline of the digits. This achieves your desired visual effect without disturbing the vertical centering of the overall component.