### PR TITLE
feat(ui): Rework and polish the 'Add/Edit Order' modal

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -252,3 +252,51 @@ span.flatpickr-weekday {
 .flatpickr-time input:hover, .flatpickr-time .flatpickr-am-pm:hover {
     background: var(--bg);
 }
+
+/* Styles for the two-part license plate input */
+.plate-input-group {
+    display: flex;
+    align-items: center;
+}
+.plate-main-input {
+    flex-grow: 1;
+    border-radius: 8px 0 0 8px !important;
+    border-right: none !important;
+    text-transform: uppercase;
+}
+.plate-region-input {
+    flex-grow: 0;
+    flex-basis: 70px;
+    border-radius: 0 8px 8px 0 !important;
+    text-align: center;
+}
+.plate-main-input:focus, .plate-region-input:focus {
+    z-index: 2;
+}
+
+/* Styles for the phone input with prefix */
+.phone-input-group {
+    display: flex;
+    align-items: center;
+}
+.phone-input-group .phone-prefix {
+    padding: 0 12px;
+    height: 48px;
+    line-height: 48px;
+    background-color: var(--bg);
+    border: 1px solid var(--border);
+    border-right: none;
+    border-radius: 8px 0 0 8px;
+    color: var(--text-muted);
+}
+.phone-input-group input[type="tel"] {
+    border-radius: 0 8px 8px 0 !important;
+}
+.phone-input-group input[type="tel"]:focus {
+    z-index: 2;
+}
+
+/* Styles for a smaller amount input */
+.amount-input {
+    max-width: 150px;
+}

--- a/css/components/modal.css
+++ b/css/components/modal.css
@@ -43,7 +43,26 @@
   border: none;
 }
 .modal-body .form-group {
-  margin-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+.compact-form .form-group {
+    margin-bottom: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start; /* Enforce left-alignment */
+}
+.compact-form .form-group label {
+    margin-bottom: 0.25rem;
+}
+.compact-form .form-row {
+    align-items: flex-start;
+}
+.form-group-small {
+    flex-grow: 0 !important;
+    flex-shrink: 1 !important;
+}
+.form-group-small input {
+    max-width: 120px;
 }
 .modal-body .form-group:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
This commit implements Phase 1 of the modal rework plan based on your detailed feedback. The focus was on improving the layout and usability of the 'Add/Edit Order' modal form.

Key changes include:

- **Compact Layout:** The form fields have been rearranged into a more compact, multi-column layout to prevent vertical scrolling on smaller screens.
- **Two-Part License Plate Input:** The single text input for license plates has been replaced with a two-part input (main number and region) for better usability and data entry.
- **Phone Number Prefix:** A static `+7` prefix has been added to the phone input field.
- **Field Resizing:** The 'Amount' input field has been resized to be narrower and more appropriate for its content.