### PR TITLE
fix: Refine login page styling based on your feedback

### DIFF
--- a/css/pages/login.css
+++ b/css/pages/login.css
@@ -25,9 +25,9 @@
 .login-car-image {
   display: block;
   width: 100%;
-  max-width: 200px;
+  max-width: 100px;
   margin: 0 auto 1.5rem auto;
-  opacity: 0.6;
+  opacity: 1;
 }
 
 .input-wrapper { position: relative; }


### PR DESCRIPTION
This commit applies further styling adjustments to the login page to achieve a more laconic and less image-focused design.

- Makes the car image fully opaque (opacity: 1).
- Reduces the max-width of the car image to 100px to de-emphasize it.